### PR TITLE
Split scripts into jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ cache: cargo
 before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
   - (which rustfmt && cargo fmt --version) || cargo install rustfmt-nightly --force
-script:
-  - cargo build
-  - cargo fmt -- --write-mode=diff
-  - cargo test
+jobs:
+  include:
+    - stage: build
+      script: cargo build
+    - stage: lint
+      script: cargo fmt -- --write-mode=diff
+    - stage: test
+      script: cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
     - stage: build
       script: cargo build
     - stage: lint
+      script: cargo build
       script: cargo fmt -- --write-mode=diff
     - stage: test
       script: cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ jobs:
     - stage: build
       script: cargo build
     - stage: lint
-      script: cargo build
-      script: cargo fmt -- --write-mode=diff
+      scripts:
+        - cargo build
+        - cargo fmt -- --write-mode=diff
     - stage: test
       script: cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
     - stage: build
       script: cargo build
     - stage: lint
-      scripts:
+      script:
         - cargo build
         - cargo fmt -- --write-mode=diff
     - stage: test


### PR DESCRIPTION
Note: Due to the build.rs script cargo build needs to be run in the lint stage as well